### PR TITLE
🧹 Rename unused parameter 'req' to '_req' in health check controller

### DIFF
--- a/lib/api/health/controller/health.ts
+++ b/lib/api/health/controller/health.ts
@@ -1,5 +1,5 @@
 import { FastifyReply, FastifyRequest } from 'fastify'
 
-export function check(req: FastifyRequest, reply: FastifyReply) {
+export function check(_req: FastifyRequest, reply: FastifyReply) {
   reply.send({ ok: true })
 }


### PR DESCRIPTION
🎯 **What:** Renamed unused parameter `req` to `_req` in `lib/api/health/controller/health.ts`.
💡 **Why:** This improves maintainability and readability by explicitly marking the parameter as unused, following the standard convention in this codebase.
✅ **Verification:** Manually verified the change and confirmed it adheres to the project's coding style. A code review was also performed and approved.
✨ **Result:** The code health issue is resolved without any change in functionality.

---
*PR created automatically by Jules for task [16420079859849559733](https://jules.google.com/task/16420079859849559733) started by @mrddter*